### PR TITLE
Add chunkSize to more efficiently display cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ yarn add react-native-reanimated react-native-gesture-handler
 | swipeLeft  | callback | Animates the card to fling to the left and calls onSwipeLeft   |
 | swipeTop   | callback | Animates the card to fling to the top and calls onSwipeTop     |
 
+## Misc props
+
+| props      | type    | description                                                   | default                                    |
+| :--------- | :------ | :------------------------------------------------------------ | :----------------------------------------- |
+| chunkSize  | number  | The number of cards rendered at a given time                  | `3`                                        |
+
 ## Usage 🧑‍💻
 
 ```typescript
@@ -369,6 +375,10 @@ type SwiperOptions<T> = {
   OverlayLabelRight?: () => JSX.Element;
   OverlayLabelLeft?: () => JSX.Element;
   OverlayLabelTop?: () => JSX.Element;
+   /*
+   * Misc Props
+   */
+  chunkSize?: number;
 };
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ export type SwiperOptions<T> = {
   OverlayLabelRight?: () => JSX.Element;
   OverlayLabelLeft?: () => JSX.Element;
   OverlayLabelTop?: () => JSX.Element;
+  //* Misc
+  chunkSize?: number;
 };
 export type SwiperCardOptions = {
   index: number;


### PR DESCRIPTION
Awesome package! I had 70+ cards which was causing the Swiper to lag, so I only display {chunkSize} cards at a time