### PR TITLE
fix: reverse cards render order to align element hierarchy with z-index

### DIFF
--- a/src/Swiper.tsx
+++ b/src/Swiper.tsx
@@ -147,7 +147,7 @@ const Swiper = <T,>(
         {renderCard(item, index)}
       </SwiperCard>
     );
-  });
+  }).reverse(); // to render cards in same hierarchy as their z-index
 };
 
 function fixedForwardRef<T, P = {}>(


### PR DESCRIPTION
After migrating my app from JS-based navigation (`@react-navigation/stack`) to native navigation (`@react-navigation/native-stack`) I encountered the following visual glitch when navigating backwards on Android:
[RN-Swiper Android zIndex Issue.webm](https://github.com/user-attachments/assets/b8d1eb5d-bb1e-419a-913e-7c481d09ab6e)
There seems to be an issue where the zIndex is disregarded in favor of the element render order during the animation.

I even found a similar bug in this open issue for `react-native-screens`:
https://github.com/software-mansion/react-native-screens/issues/1546
The only known "solution" is to align the element hierarchy with the zIndex by putting the last rendered/highest component at the bottom and vice-versa.

This PR simply reverses the mapped SwiperCards to render them in the correct hierarchy inside of the element tree without altering any indexes, animation or logic. Everything works the same and has no user- or developer-facing impact, besides fixing this visual glitch under the hood. I did not find any way to fix this outside of the library in the app's scope.

I believe this is not a niche issue, because it occurs in minimal setups with `@react-navigation/native-stack`. It maybe also affects apps using `expo-router`, because [their default Stack navigator wraps that](https://docs.expo.dev/router/advanced/stack/#relation-with-native-stack-navigator).
At the end, it seems pretty logical to me to have the cards in the same order inside the element tree as they are rendered on top of each other.