### PR TITLE
feat: add swipeVelocityThreshold prop for velocity-based swiping

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ yarn add react-native-reanimated react-native-gesture-handler
 | disableLeftSwipe  | bool | If true, disables the ability to swipe left.    | `false` |
 | disableRightSwipe | bool | If true, disables the ability to swipe right.   | `false` |
 | disableTopSwipe   | bool | If true, disables the ability to swipe upwards. | `false` |
+| swipeVelocityThreshold| number | Sets the minimum velocity (in px/s) required to trigger a swipe regardless of card position. If undefined, velocity-based swiping is disabled. | `undefined` |
 
 ## Rotation Animation Props
 
@@ -417,6 +418,10 @@ type SwiperOptions<T> = {
   swipeLeftSpringConfig?: SpringConfig;
   swipeTopSpringConfig?: SpringConfig;
   swipeBottomSpringConfig?: SpringConfig;
+  /*
+   * Swipe Velocity Threshold
+   */
+  swipeVelocityThreshold?: number;
 };
 ```
 

--- a/src/Swiper.tsx
+++ b/src/Swiper.tsx
@@ -62,6 +62,7 @@ const Swiper = <T,>(
     loop = false,
     keyExtractor,
     onPress,
+    swipeVelocityThreshold,
   }: SwiperOptions<T>,
   ref: ForwardedRef<SwiperCardRefType>
 ) => {
@@ -176,6 +177,7 @@ const Swiper = <T,>(
           swipeTopSpringConfig={swipeTopSpringConfig}
           swipeBottomSpringConfig={swipeBottomSpringConfig}
           onPress={onPress}
+          swipeVelocityThreshold={swipeVelocityThreshold}
         >
           {renderCard(item, index)}
         </SwiperCard>

--- a/src/SwiperCard/index.tsx
+++ b/src/SwiperCard/index.tsx
@@ -66,6 +66,7 @@ const SwipeableCard = forwardRef<
       swipeTopSpringConfig,
       swipeBottomSpringConfig,
       onPress,
+      swipeVelocityThreshold,
     },
     ref
   ) => {
@@ -217,6 +218,33 @@ const SwipeableCard = forwardRef<
         const currentActive = Math.floor(activeIndex.value);
         if (currentActive !== index) return;
         if (onSwipeEnd) runOnJS(onSwipeEnd)();
+
+        if (swipeVelocityThreshold !== undefined) {
+          if (Math.abs(event.velocityX) > swipeVelocityThreshold) {
+            const sign = Math.sign(event.velocityX);
+            if (sign === -1 && !disableLeftSwipe) {
+              runOnJS(swipeLeft)();
+              return;
+            }
+            if (sign === 1 && !disableRightSwipe) {
+              runOnJS(swipeRight)();
+              return;
+            }
+          }
+
+          if (Math.abs(event.velocityY) > swipeVelocityThreshold) {
+            const sign = Math.sign(event.velocityY);
+            if (sign === -1 && !disableTopSwipe) {
+              runOnJS(swipeTop)();
+              return;
+            }
+            if (sign === 1 && !disableBottomSwipe) {
+              runOnJS(swipeBottom)();
+              return;
+            }
+          }
+        }
+
         if (nextActiveIndex.value === activeIndex.value + 1) {
           const sign = Math.sign(event.translationX);
           const signY = Math.sign(event.translationY);

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export type SwiperOptions<T> = {
   swipeTopSpringConfig?: SpringConfig;
   swipeBottomSpringConfig?: SpringConfig;
   keyExtractor?: (item: T, index: number) => string;
+  swipeVelocityThreshold?: number;
 };
 export type SwiperCardOptions = {
   index: number;
@@ -105,4 +106,5 @@ export type SwiperCardOptions = {
   swipeLeftSpringConfig?: SpringConfig;
   swipeTopSpringConfig?: SpringConfig;
   swipeBottomSpringConfig?: SpringConfig;
+  swipeVelocityThreshold?: number;
 };


### PR DESCRIPTION
Currently, cards only dismiss when dragged to a specific distance (controlled by translateXRange and translateYRange). I’ve added a swipeVelocityThreshold prop to also allow dismissal based on swipe speed, this allows for more flexibility.

swipeVelocityThreshold prop is optional and Swiper will only respond to swiping speed if this property is passed.
