### PR TITLE
feat(card): Implement flip-on-press functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ These parameters can be adjusted to achieve the desired animation behavior for t
 ## Usage 🧑‍💻
 
 ```typescript
-/* eslint-disable react-native/no-inline-styles */
 import React, { useCallback, useRef } from 'react';
 import {
   Image,
   StyleSheet,
+  Text,
   View,
   type ImageSourcePropType,
 } from 'react-native';
@@ -164,18 +164,27 @@ const IMAGES: ImageSourcePropType[] = [
   require('../assets/images/6.jpg'),
 ];
 
+const ICON_SIZE = 24;
+
 const App = () => {
   const ref = useRef<SwiperCardRefType>();
 
-  const renderCard = useCallback(
-    (image: ImageSourcePropType) => {
+  const renderCard = useCallback((image: ImageSourcePropType) => {
+    return (
+      <View style={styles.renderCardContainer}>
+        <Image
+          source={image}
+          style={styles.renderCardImage}
+          resizeMode="cover"
+        />
+      </View>
+    );
+  }, []);
+  const renderFlippedCard = useCallback(
+    (_: ImageSourcePropType, index: number) => {
       return (
-        <View style={styles.renderCardContainer}>
-          <Image
-            source={image}
-            style={styles.renderCardImage}
-            resizeMode="cover"
-          />
+        <View style={styles.renderFlippedCardContainer}>
+          <Text style={styles.text}>Flipped content 🚀 {index}</Text>
         </View>
       );
     },
@@ -217,14 +226,27 @@ const App = () => {
       />
     );
   }, []);
+  const OverlayLabelBottom = useCallback(() => {
+    return (
+      <View
+        style={[
+          styles.overlayLabelContainer,
+          {
+            backgroundColor: 'orange',
+          },
+        ]}
+      />
+    );
+  }, []);
 
   return (
     <GestureHandlerRootView style={styles.container}>
       <View style={styles.subContainer}>
         <Swiper
           ref={ref}
-          cardStyle={styles.cardStyle}
           data={IMAGES}
+          cardStyle={styles.cardStyle}
+          overlayLabelContainerStyle={styles.overlayLabelContainerStyle}
           renderCard={renderCard}
           onIndexChange={(index) => {
             console.log('Current Active index', index);
@@ -238,15 +260,20 @@ const App = () => {
           onSwipedAll={() => {
             console.log('onSwipedAll');
           }}
+          FlippedContent={renderFlippedCard}
           onSwipeLeft={(cardIndex) => {
             console.log('onSwipeLeft', cardIndex);
           }}
           onSwipeTop={(cardIndex) => {
             console.log('onSwipeTop', cardIndex);
           }}
+          onSwipeBottom={(cardIndex) => {
+            console.log('onSwipeBottom', cardIndex);
+          }}
           OverlayLabelRight={OverlayLabelRight}
           OverlayLabelLeft={OverlayLabelLeft}
           OverlayLabelTop={OverlayLabelTop}
+          OverlayLabelBottom={OverlayLabelBottom}
           onSwipeActive={() => {
             console.log('onSwipeActive');
           }}
@@ -263,18 +290,34 @@ const App = () => {
         <ActionButton
           style={styles.button}
           onTap={() => {
-            ref.current?.swipeLeft();
+            ref.current?.flipCard();
           }}
         >
-          <AntDesign name="close" size={32} color="white" />
+          <AntDesign name="sync" size={ICON_SIZE} color="white" />
         </ActionButton>
         <ActionButton
-          style={[styles.button, { height: 60, marginHorizontal: 10 }]}
+          style={styles.button}
           onTap={() => {
             ref.current?.swipeBack();
           }}
         >
-          <AntDesign name="reload1" size={24} color="white" />
+          <AntDesign name="reload1" size={ICON_SIZE} color="white" />
+        </ActionButton>
+        <ActionButton
+          style={styles.button}
+          onTap={() => {
+            ref.current?.swipeLeft();
+          }}
+        >
+          <AntDesign name="close" size={ICON_SIZE} color="white" />
+        </ActionButton>
+        <ActionButton
+          style={styles.button}
+          onTap={() => {
+            ref.current?.swipeBottom();
+          }}
+        >
+          <AntDesign name="arrowdown" size={ICON_SIZE} color="white" />
         </ActionButton>
         <ActionButton
           style={styles.button}
@@ -282,7 +325,7 @@ const App = () => {
             ref.current?.swipeTop();
           }}
         >
-          <AntDesign name="arrowup" size={32} color="white" />
+          <AntDesign name="arrowup" size={ICON_SIZE} color="white" />
         </ActionButton>
         <ActionButton
           style={styles.button}
@@ -290,7 +333,7 @@ const App = () => {
             ref.current?.swipeRight();
           }}
         >
-          <AntDesign name="heart" size={32} color="white" />
+          <AntDesign name="heart" size={ICON_SIZE} color="white" />
         </ActionButton>
       </View>
     </GestureHandlerRootView>
@@ -310,11 +353,11 @@ const styles = StyleSheet.create({
     bottom: 34,
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 24,
   },
   button: {
-    height: 80,
+    height: 50,
     borderRadius: 40,
-    marginHorizontal: 20,
     aspectRatio: 1,
     backgroundColor: '#3A3D45',
     elevation: 4,
@@ -327,21 +370,29 @@ const styles = StyleSheet.create({
       height: 4,
     },
   },
+  renderCardContainer: {
+    borderRadius: 15,
+    width: '100%',
+    height: '100%',
+  },
+  renderFlippedCardContainer: {
+    borderRadius: 15,
+    backgroundColor: '#baeee5',
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   buttonText: {
     fontSize: 20,
     fontWeight: 'bold',
   },
   cardStyle: {
-    width: '95%',
-    height: '75%',
+    width: '90%',
+    height: '90%',
     borderRadius: 15,
-    marginVertical: 20,
-  },
-  renderCardContainer: {
-    flex: 1,
-    borderRadius: 15,
-    height: '75%',
-    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   renderCardImage: {
     height: '100%',
@@ -354,13 +405,18 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   overlayLabelContainer: {
-    width: '100%',
-    height: '100%',
     borderRadius: 15,
+    height: '90%',
+    width: '90%',
+  },
+  text: {
+    color: '#001a72',
+  },
+  overlayLabelContainerStyle: {
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
-
-
 ```
 
 For more examples check out the [example](https://github.com/Skipperlla/rn-swiper-list/blob/main/example/src/App.tsx) folder 📂

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ yarn add react-native-reanimated react-native-gesture-handler
 - [x] Swipe back to previous card with a custom animation
 - [x] More swipe events callbacks
 - [x] Integrating and using a single card with flatlist
+- [x] Flip card on press to show more details
 
 # Props ✏️
 
@@ -72,6 +73,7 @@ yarn add react-native-reanimated react-native-gesture-handler
 | disableRightSwipe | bool | If true, disables the ability to swipe right.   | `false` |
 | disableTopSwipe   | bool | If true, disables the ability to swipe upwards. | `false` |
 | swipeVelocityThreshold| number | Sets the minimum velocity (in px/s) required to trigger a swipe regardless of card position. If undefined, velocity-based swiping is disabled. | `undefined` |
+| disableBottomSwipe| bool | If true, disables the ability to swipe downwards. | `false` |
 
 ## Rotation Animation Props
 
@@ -81,6 +83,10 @@ yarn add react-native-reanimated react-native-gesture-handler
 | translateYRange     | array | Translates the card vertically.                               | `[-windowHeight / 3, 0, windowHeight / 3]` |
 | rotateInputRange    | array | Array specifying the range of x values for rotation mapping.  | `[-windowWidth / 3, 0, windowWidth / 3]`   |
 | outputRotationRange | array | Array of rotation values corresponding to `rotateInputRange`. | `[-Math.PI / 20, 0, Math.PI / 20]`         |
+| inputOverlayLabelTopOpacityRange    | array             | Array defining the input range for animating the opacity of the top overlay label.                      | `[0, -(windowHeight / 3)]` |
+| outputOverlayLabelTopOpacityRange   | array             | Array defining the output opacity values for the top overlay label, corresponding to the input range.   | `[0, 1]`                   |
+| inputOverlayLabelBottomOpacityRange  | array             | Array defining the input range for animating the opacity of the bottom overlay label.                   | `[0, windowHeight / 3]`    |
+| outputOverlayLabelBottomOpacityRange | array             | Array defining the output opacity values for the bottom overlay label, corresponding to the input range. | `[0, 1]`                   |
 
 ## Overlay Labels Animation Props
 
@@ -90,11 +96,10 @@ yarn add react-native-reanimated react-native-gesture-handler
 | outputOverlayLabelRightOpacityRange | array             | Array defining the output opacity values for the right overlay label, corresponding to the input range. | `[0, 1]`                   |
 | inputOverlayLabelLeftOpacityRange   | array             | Array defining the input range for animating the opacity of the left overlay label.                     | `[0, -(windowWidth / 3)]`  |
 | outputOverlayLabelLeftOpacityRange  | array             | Array defining the output opacity values for the left overlay label, corresponding to the input range.  | `[0, 1]`                   |
-| inputOverlayLabelTopOpacityRange    | array             | Array defining the input range for animating the opacity of the top overlay label.                      | `[0, -(windowHeight / 3)]` |
-| outputOverlayLabelTopOpacityRange   | array             | Array defining the output opacity values for the top overlay label, corresponding to the input range.   | `[0, 1]`                   |
 | OverlayLabelRight                   | () => JSX.Element | Component rendered as an overlay label for right swipes.                                                |                            |
 | OverlayLabelLeft                    | () => JSX.Element | Component rendered as an overlay label for left swipes.                                                 |                            |
 | OverlayLabelTop                     | () => JSX.Element | Component rendered as an overlay label for top swipes.                                                  |                            |
+| OverlayLabelBottom                  | () => JSX.Element | Component rendered as an overlay label for bottom swipes.                                               |                            |
 
 ## Flip Animation Props
 
@@ -111,6 +116,8 @@ yarn add react-native-reanimated react-native-gesture-handler
 | swipeRight | callback | Animates the card to fling to the right and calls onSwipeRight |
 | swipeLeft  | callback | Animates the card to fling to the left and calls onSwipeLeft   |
 | swipeTop   | callback | Animates the card to fling to the top and calls onSwipeTop     |
+| swipeBottom| callback | Animates the card to fling to the bottom and calls onSwipeBottom|
+| flipCard   | callback | Flips the card to show the back content                        |
 
 ## Swipe Animation Spring Configs (Animation Speed)
 
@@ -430,6 +437,8 @@ type SwiperCardRefType =
       swipeLeft: () => void;
       swipeBack: () => void;
       swipeTop: () => void;
+      swipeBottom: () => void;
+      flipCard: () => void;
     }
   | undefined;
 
@@ -441,22 +450,33 @@ type SwiperOptions<T> = {
   renderCard: (item: T, index: number) => JSX.Element;
   prerenderItems?: number;
   cardStyle?: StyleProp<ViewStyle>;
+  flippedCardStyle?: StyleProp<ViewStyle>;
+  regularCardStyle?: StyleProp<ViewStyle>;
+  overlayLabelContainerStyle?: StyleProp<ViewStyle>;
+  keyExtractor?: (item: T, index: number) => string | number;
+  FlippedContent?: (item: T, index: number) => JSX.Element;
+  loop?: boolean;
+  keyExtractor?: (item: T, index: number) => string | number;
   /*
    * Children components
    */
   onSwipeLeft?: (cardIndex: number) => void;
   onSwipeRight?: (cardIndex: number) => void;
   onSwipeTop?: (cardIndex: number) => void;
+  onSwipeBottom?: (cardIndex: number) => void;
   onSwipedAll?: () => void;
   onSwipeStart?: () => void;
   onSwipeEnd?: () => void;
   onSwipeActive?: () => void;
+  onPress?: () => void;
+  onIndexChange?: (index: number) => void;
   /*
    * Swipe methods
    */
   disableRightSwipe?: boolean;
   disableLeftSwipe?: boolean;
   disableTopSwipe?: boolean;
+  disableBottomSwipe?: boolean;
   /*
    * Rotation Animation Props
    */
@@ -473,9 +493,17 @@ type SwiperOptions<T> = {
   outputOverlayLabelLeftOpacityRange?: number[];
   inputOverlayLabelTopOpacityRange?: number[];
   outputOverlayLabelTopOpacityRange?: number[];
+  inputOverlayLabelBottomOpacityRange?: number[];
+  outputOverlayLabelBottomOpacityRange?: number[];
   OverlayLabelRight?: () => JSX.Element;
   OverlayLabelLeft?: () => JSX.Element;
   OverlayLabelTop?: () => JSX.Element;
+  OverlayLabelBottom?: () => JSX.Element;
+  /*
+   * Flip Animation Props
+   */
+  direction?: 'x' | 'y';
+  flipDuration?: number;
   /*
    * Swipe Animation Spring Configs (Animation Speed)
    */

--- a/README.md
+++ b/README.md
@@ -35,15 +35,19 @@ yarn add react-native-reanimated react-native-gesture-handler
 
 ## Card Props
 
-| Props        | type                     | description                                                                            | required | default        |
-| :----------- | :----------------------- | :------------------------------------------------------------------------------------- | :------- | :------------- |
-| data         | array                    | Array of data objects used to render the cards.                                        | Yes      |                |
-| renderCard   | func(cardData,cardIndex) | Function that renders a card based on the provided data and index.                     | Yes      |                |
-| prerenderItems | number                 | Number of cards to prerender ahead of the active card for better performance.           | No       | data.length - 1|
-| cardStyle    | object                   | CSS style properties applied to each card. These can be applied inline.                |          |                |
-| keyExtractor | func                     | Function that returns a unique key for each card based on the provided data.           | No       |                |
-| children     | React.ReactNode          | Child components to be displayed inside the component. Used typically for composition. |          |                |
-| loop         | bool                     | If true, the swiper will loop back to the first card after the last card is swiped.    | No       | false          |
+| Props                      | type                     | description                                                                            | required | default         |
+| :------------------------- | :----------------------- | :------------------------------------------------------------------------------------- | :------- | :-------------- |
+| data                       | array                    | Array of data objects used to render the cards.                                        | Yes      |                 |
+| renderCard                 | func(cardData,cardIndex) | Function that renders a card based on the provided data and index.                     | Yes      |                 |
+| prerenderItems             | number                   | Number of cards to prerender ahead of the active card for better performance.          | No       | data.length - 1 |
+| cardStyle                  | object                   | CSS style properties applied to each card. These can be applied inline.                |          |                 |
+| flippedCardStyle           | object                   | CSS style properties for the back of the card.                                         |          |                 |
+| regularCardStyle           | object                   | CSS style properties for the front of the card.                                        |          |                 |
+| overlayLabelContainerStyle | object                   | CSS style properties for the overlay label container.                                  |          |                 |
+| keyExtractor               | func                     | Function that returns a unique key for each card based on the provided data.           | No       |                 |
+| children                   | React.ReactNode          | Child components to be displayed inside the component. Used typically for composition. |          |                 |
+| FlippedContent             | func(item, index)        | Function that renders the content for the back of the card.                            | No       |                 |
+| loop                       | bool                     | If true, the swiper will loop back to the first card after the last card is swiped.    | No       | false           |
 
 ## Event callbacks
 
@@ -92,6 +96,13 @@ yarn add react-native-reanimated react-native-gesture-handler
 | OverlayLabelLeft                    | () => JSX.Element | Component rendered as an overlay label for left swipes.                                                 |                            |
 | OverlayLabelTop                     | () => JSX.Element | Component rendered as an overlay label for top swipes.                                                  |                            |
 
+## Flip Animation Props
+
+| props        | type       | description                               | default |
+| :----------- | :--------- | :---------------------------------------- | :------ |
+| direction    | 'x' \| 'y' | The direction of the flip animation.      | `'y'`   |
+| flipDuration | number     | The duration of the flip animation in ms. | `500`   |
+
 ## Swipe methods
 
 | props      | type     | description                                                    |
@@ -103,13 +114,13 @@ yarn add react-native-reanimated react-native-gesture-handler
 
 ## Swipe Animation Spring Configs (Animation Speed)
 
-| props                  | type         | description                                                  |
-| :--------------------- | :----------- | :----------------------------------------------------------- |
-| swipeBackXSpringConfig | SpringConfig | Spring configuration for swipe back animation on the X-axis. |
-| swipeBackYSpringConfig | SpringConfig | Spring configuration for swipe back animation on the Y-axis. |
-| swipeRightSpringConfig | SpringConfig | Spring configuration for swipe right animation on the X-axis. |
-| swipeLeftSpringConfig  | SpringConfig | Spring configuration for swipe left animation on the X-axis.  |
-| swipeTopSpringConfig   | SpringConfig | Spring configuration for swipe top animation on the Y-axis. |
+| props                   | type         | description                                                    |
+| :---------------------- | :----------- | :------------------------------------------------------------- |
+| swipeBackXSpringConfig  | SpringConfig | Spring configuration for swipe back animation on the X-axis.   |
+| swipeBackYSpringConfig  | SpringConfig | Spring configuration for swipe back animation on the Y-axis.   |
+| swipeRightSpringConfig  | SpringConfig | Spring configuration for swipe right animation on the X-axis.  |
+| swipeLeftSpringConfig   | SpringConfig | Spring configuration for swipe left animation on the X-axis.   |
+| swipeTopSpringConfig    | SpringConfig | Spring configuration for swipe top animation on the Y-axis.    |
 | swipeBottomSpringConfig | SpringConfig | Spring configuration for swipe bottom animation on the Y-axis. |
 
 ### What is Spring Config?

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useRef } from 'react';
 import {
   Image,
   StyleSheet,
+  Text,
   View,
   type ImageSourcePropType,
 } from 'react-native';
@@ -37,6 +38,16 @@ const App = () => {
       </View>
     );
   }, []);
+  const renderFlippedCard = useCallback(
+    (_: ImageSourcePropType, index: number) => {
+      return (
+        <View style={styles.renderFlippedCardContainer}>
+          <Text style={styles.text}>Flipped content 🚀 {index}</Text>
+        </View>
+      );
+    },
+    []
+  );
   const OverlayLabelRight = useCallback(() => {
     return (
       <View
@@ -91,8 +102,9 @@ const App = () => {
       <View style={styles.subContainer}>
         <Swiper
           ref={ref}
-          cardStyle={styles.cardStyle}
           data={IMAGES}
+          cardStyle={styles.cardStyle}
+          overlayLabelContainerStyle={styles.overlayLabelContainerStyle}
           renderCard={renderCard}
           onIndexChange={(index) => {
             console.log('Current Active index', index);
@@ -106,6 +118,7 @@ const App = () => {
           onSwipedAll={() => {
             console.log('onSwipedAll');
           }}
+          FlippedContent={renderFlippedCard}
           onSwipeLeft={(cardIndex) => {
             console.log('onSwipeLeft', cardIndex);
           }}
@@ -132,6 +145,14 @@ const App = () => {
       </View>
 
       <View style={styles.buttonsContainer}>
+        <ActionButton
+          style={styles.button}
+          onTap={() => {
+            ref.current?.flipCard();
+          }}
+        >
+          <AntDesign name="sync" size={ICON_SIZE} color="white" />
+        </ActionButton>
         <ActionButton
           style={styles.button}
           onTap={() => {
@@ -207,21 +228,29 @@ const styles = StyleSheet.create({
       height: 4,
     },
   },
+  renderCardContainer: {
+    borderRadius: 15,
+    width: '100%',
+    height: '100%',
+  },
+  renderFlippedCardContainer: {
+    borderRadius: 15,
+    backgroundColor: '#baeee5',
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   buttonText: {
     fontSize: 20,
     fontWeight: 'bold',
   },
   cardStyle: {
-    width: '95%',
-    height: '75%',
+    width: '90%',
+    height: '90%',
     borderRadius: 15,
-    marginVertical: 20,
-  },
-  renderCardContainer: {
-    flex: 1,
-    borderRadius: 15,
-    height: '75%',
-    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   renderCardImage: {
     height: '100%',
@@ -234,8 +263,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   overlayLabelContainer: {
-    width: '100%',
-    height: '100%',
     borderRadius: 15,
+    height: '90%',
+    width: '90%',
+  },
+  text: {
+    color: '#001a72',
+  },
+  overlayLabelContainerStyle: {
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/src/Swiper.tsx
+++ b/src/Swiper.tsx
@@ -1,7 +1,11 @@
 import React, { useImperativeHandle, type ForwardedRef } from 'react';
 import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 import { Dimensions } from 'react-native';
-import type { SwiperCardRefType, SwiperOptions } from 'rn-swiper-list';
+import type {
+  SwiperCardRefType,
+  SwiperOptions,
+  SwiperCardOptions,
+} from 'rn-swiper-list';
 
 import useSwipeControls from './hooks/useSwipeControls';
 import SwiperCard from './SwiperCard';
@@ -30,6 +34,8 @@ const Swiper = <T,>(
     onSwipeBottom,
     onIndexChange,
     cardStyle,
+    flippedCardStyle,
+    regularCardStyle,
     disableRightSwipe,
     disableLeftSwipe,
     disableTopSwipe,
@@ -63,6 +69,10 @@ const Swiper = <T,>(
     keyExtractor,
     onPress,
     swipeVelocityThreshold,
+    FlippedContent,
+    direction = 'y',
+    flipDuration = 500,
+    overlayLabelContainerStyle,
   }: SwiperOptions<T>,
   ref: ForwardedRef<SwiperCardRefType>
 ) => {
@@ -74,6 +84,7 @@ const Swiper = <T,>(
     swipeBack,
     swipeTop,
     swipeBottom,
+    flipCard,
   } = useSwipeControls(data, loop);
 
   useImperativeHandle(
@@ -85,9 +96,10 @@ const Swiper = <T,>(
         swipeBack,
         swipeTop,
         swipeBottom,
+        flipCard,
       };
     },
-    [swipeLeft, swipeRight, swipeBack, swipeTop, swipeBottom]
+    [swipeLeft, swipeRight, swipeBack, swipeTop, swipeBottom, flipCard]
   );
 
   useAnimatedReaction(
@@ -115,12 +127,20 @@ const Swiper = <T,>(
     []
   );
 
+  const Card = SwiperCard as unknown as React.ComponentType<
+    React.PropsWithChildren<SwiperCardOptions<T>> & {
+      ref?: React.Ref<SwiperCardRefType>;
+    }
+  >;
+
   return data
     .map((item, index) => {
       return (
-        <SwiperCard
+        <Card
           key={keyExtractor ? keyExtractor(item, index) : index}
           cardStyle={cardStyle}
+          flippedCardStyle={flippedCardStyle}
+          regularCardStyle={regularCardStyle}
           index={index}
           prerenderItems={prerenderItems}
           disableRightSwipe={disableRightSwipe}
@@ -155,18 +175,19 @@ const Swiper = <T,>(
           OverlayLabelTop={OverlayLabelTop}
           OverlayLabelBottom={OverlayLabelBottom}
           ref={refs[index]}
-          onSwipeRight={(cardIndex) => {
+          onSwipeRight={(cardIndex: number) => {
             onSwipeRight?.(cardIndex);
           }}
-          onSwipeLeft={(cardIndex) => {
+          onSwipeLeft={(cardIndex: number) => {
             onSwipeLeft?.(cardIndex);
           }}
-          onSwipeTop={(cardIndex) => {
+          onSwipeTop={(cardIndex: number) => {
             onSwipeTop?.(cardIndex);
           }}
-          onSwipeBottom={(cardIndex) => {
+          onSwipeBottom={(cardIndex: number) => {
             onSwipeBottom?.(cardIndex);
           }}
+          FlippedContent={FlippedContent}
           onSwipeStart={onSwipeStart}
           onSwipeActive={onSwipeActive}
           onSwipeEnd={onSwipeEnd}
@@ -178,9 +199,13 @@ const Swiper = <T,>(
           swipeBottomSpringConfig={swipeBottomSpringConfig}
           onPress={onPress}
           swipeVelocityThreshold={swipeVelocityThreshold}
+          item={item}
+          direction={direction}
+          flipDuration={flipDuration}
+          overlayLabelContainerStyle={overlayLabelContainerStyle}
         >
           {renderCard(item, index)}
-        </SwiperCard>
+        </Card>
       );
     })
     .reverse(); // to render cards in same hierarchy as their z-index

--- a/src/SwiperCard/OverlayLabel.tsx
+++ b/src/SwiperCard/OverlayLabel.tsx
@@ -1,5 +1,5 @@
 import React, { type PropsWithChildren } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import Animated, {
   interpolate,
   useAnimatedStyle,
@@ -11,6 +11,7 @@ type Props = PropsWithChildren<{
   outputRange?: number[];
   Component: () => JSX.Element;
   opacityValue: SharedValue<number>;
+  overlayLabelContainerStyle?: StyleProp<ViewStyle>;
 }>;
 
 const OverlayLabel = ({
@@ -18,6 +19,7 @@ const OverlayLabel = ({
   outputRange,
   Component,
   opacityValue,
+  overlayLabelContainerStyle,
 }: Props) => {
   const animatedStyle = useAnimatedStyle(() => {
     return {
@@ -33,7 +35,11 @@ const OverlayLabel = ({
 
   return (
     <Animated.View
-      style={[StyleSheet.absoluteFillObject, animatedStyle]}
+      style={[
+        StyleSheet.absoluteFillObject,
+        animatedStyle,
+        overlayLabelContainerStyle,
+      ]}
       pointerEvents="none"
     >
       <Component />

--- a/src/SwiperCard/OverlayLabel.tsx
+++ b/src/SwiperCard/OverlayLabel.tsx
@@ -29,7 +29,7 @@ const OverlayLabel = ({
         outputRange ?? [],
         'clamp'
       ),
-      zIndex: 2,
+      zIndex: 3,
     };
   });
 

--- a/src/SwiperCard/index.tsx
+++ b/src/SwiperCard/index.tsx
@@ -237,6 +237,27 @@ const SwipeableCard = forwardRef(function SwipeableCard<T>(
             'clamp'
           )
         );
+        if (signPositionY) {
+          if (signY === -1 && !disableTopSwipe) {
+            runOnJS(swipeTop)();
+            return;
+          }
+          if (signY === 1 && !disableBottomSwipe) {
+            runOnJS(swipeBottom)();
+            return;
+          }
+        }
+
+        if (!signPositionY) {
+          if (sign === 1 && !disableRightSwipe) {
+            runOnJS(swipeRight)();
+            return;
+          }
+          if (sign === -1 && !disableLeftSwipe) {
+            runOnJS(swipeLeft)();
+            return;
+          }
+        }
       }
     })
     .onFinalize((event) => {

--- a/src/SwiperCard/index.tsx
+++ b/src/SwiperCard/index.tsx
@@ -5,7 +5,7 @@ import React, {
   useImperativeHandle,
   type PropsWithChildren,
 } from 'react';
-import { useWindowDimensions } from 'react-native';
+import { useWindowDimensions, StyleSheet } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   cancelAnimation,
@@ -21,341 +21,417 @@ import type { SwiperCardOptions, SwiperCardRefType } from 'rn-swiper-list';
 
 import OverlayLabel from './OverlayLabel';
 
-const SwipeableCard = forwardRef<
-  SwiperCardRefType,
-  PropsWithChildren<SwiperCardOptions>
->(
-  (
-    {
-      index,
-      activeIndex,
-      prerenderItems = 5,
-      onSwipeLeft,
-      onSwipeRight,
-      onSwipeTop,
-      onSwipeBottom,
-      cardStyle,
-      children,
-      disableRightSwipe,
-      disableLeftSwipe,
-      disableTopSwipe,
-      disableBottomSwipe,
-      translateXRange,
-      translateYRange,
-      rotateInputRange,
-      rotateOutputRange,
-      inputOverlayLabelRightOpacityRange,
-      outputOverlayLabelRightOpacityRange,
-      inputOverlayLabelLeftOpacityRange,
-      outputOverlayLabelLeftOpacityRange,
-      inputOverlayLabelTopOpacityRange,
-      outputOverlayLabelTopOpacityRange,
-      inputOverlayLabelBottomOpacityRange,
-      outputOverlayLabelBottomOpacityRange,
-      OverlayLabelRight,
-      OverlayLabelLeft,
-      OverlayLabelTop,
-      OverlayLabelBottom,
-      onSwipeStart,
-      onSwipeActive,
-      onSwipeEnd,
-      swipeBackXSpringConfig,
-      swipeBackYSpringConfig,
-      swipeRightSpringConfig,
-      swipeLeftSpringConfig,
-      swipeTopSpringConfig,
-      swipeBottomSpringConfig,
-      onPress,
-      swipeVelocityThreshold,
+const SwipeableCard = forwardRef(function SwipeableCard<T>(
+  props: PropsWithChildren<SwiperCardOptions<T>>,
+  ref: React.ForwardedRef<SwiperCardRefType>
+) {
+  const {
+    index,
+    item,
+    activeIndex,
+    prerenderItems = 5,
+    onSwipeLeft,
+    onSwipeRight,
+    onSwipeTop,
+    onSwipeBottom,
+    cardStyle,
+    flippedCardStyle,
+    regularCardStyle,
+    children,
+    disableRightSwipe,
+    disableLeftSwipe,
+    disableTopSwipe,
+    disableBottomSwipe,
+    translateXRange,
+    translateYRange,
+    rotateInputRange,
+    rotateOutputRange,
+    inputOverlayLabelRightOpacityRange,
+    outputOverlayLabelRightOpacityRange,
+    inputOverlayLabelLeftOpacityRange,
+    outputOverlayLabelLeftOpacityRange,
+    inputOverlayLabelTopOpacityRange,
+    outputOverlayLabelTopOpacityRange,
+    inputOverlayLabelBottomOpacityRange,
+    outputOverlayLabelBottomOpacityRange,
+    OverlayLabelRight,
+    OverlayLabelLeft,
+    OverlayLabelTop,
+    OverlayLabelBottom,
+    onSwipeStart,
+    onSwipeActive,
+    onSwipeEnd,
+    swipeBackXSpringConfig,
+    swipeBackYSpringConfig,
+    swipeRightSpringConfig,
+    swipeLeftSpringConfig,
+    swipeTopSpringConfig,
+    swipeBottomSpringConfig,
+    onPress,
+    FlippedContent,
+    direction = 'y',
+    flipDuration = 2500,
+    overlayLabelContainerStyle,
+    swipeVelocityThreshold,
+  } = props;
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const isFlipped = useSharedValue(false);
+  // Check if FlippedContent is defined and not null
+  const hasFlippedContent =
+    FlippedContent !== undefined && FlippedContent !== null;
+
+  // Don't access activeIndex.value during render - use 0 as initial value
+  // These will be updated in gesture handlers
+  const nextActiveIndex = useSharedValue(0);
+
+  const { width, height } = useWindowDimensions();
+  const maxCardTranslation = width * 1.5;
+  const maxCardTranslationY = height * 1.5;
+
+  const swipeRight = useCallback(() => {
+    onSwipeRight?.(index);
+    translateX.value = withSpring(maxCardTranslation, swipeRightSpringConfig);
+    activeIndex.value++;
+  }, [
+    index,
+    activeIndex,
+    maxCardTranslation,
+    onSwipeRight,
+    translateX,
+    swipeRightSpringConfig,
+  ]);
+
+  const swipeLeft = useCallback(() => {
+    onSwipeLeft?.(index);
+    translateX.value = withSpring(-maxCardTranslation, swipeLeftSpringConfig);
+    activeIndex.value++;
+  }, [
+    index,
+    activeIndex,
+    maxCardTranslation,
+    onSwipeLeft,
+    translateX,
+    swipeLeftSpringConfig,
+  ]);
+
+  const swipeTop = useCallback(() => {
+    onSwipeTop?.(index);
+    translateY.value = withSpring(-maxCardTranslationY, swipeTopSpringConfig);
+    activeIndex.value++;
+  }, [
+    index,
+    activeIndex,
+    maxCardTranslationY,
+    onSwipeTop,
+    translateY,
+    swipeTopSpringConfig,
+  ]);
+
+  const swipeBottom = useCallback(() => {
+    onSwipeBottom?.(index);
+    translateY.value = withSpring(maxCardTranslationY, swipeBottomSpringConfig);
+    activeIndex.value++;
+  }, [
+    index,
+    activeIndex,
+    maxCardTranslationY,
+    onSwipeBottom,
+    translateY,
+    swipeBottomSpringConfig,
+  ]);
+
+  const swipeBack = useCallback(() => {
+    cancelAnimation(translateX);
+    cancelAnimation(translateY);
+    translateX.value = withSpring(0, swipeBackXSpringConfig);
+    translateY.value = withSpring(0, swipeBackYSpringConfig);
+  }, [translateX, translateY, swipeBackXSpringConfig, swipeBackYSpringConfig]);
+
+  const flipCard = useCallback(() => {
+    if (hasFlippedContent) {
+      isFlipped.value = !isFlipped.value;
+      return;
+    }
+  }, [isFlipped, hasFlippedContent]);
+
+  useImperativeHandle(
+    ref,
+    () => {
+      return {
+        swipeLeft,
+        swipeRight,
+        swipeBack,
+        swipeTop,
+        swipeBottom,
+        flipCard,
+      };
     },
-    ref
-  ) => {
-    const translateX = useSharedValue(0);
-    const translateY = useSharedValue(0);
+    [swipeLeft, swipeRight, swipeBack, swipeTop, swipeBottom, flipCard]
+  );
 
-    // Don't access activeIndex.value during render - use 0 as initial value
-    // These will be updated in gesture handlers
-    const nextActiveIndex = useSharedValue(0);
-
-    const { width, height } = useWindowDimensions();
-    const maxCardTranslation = width * 1.5;
-    const maxCardTranslationY = height * 1.5;
-
-    const swipeRight = useCallback(() => {
-      onSwipeRight?.(index);
-      translateX.value = withSpring(maxCardTranslation, swipeRightSpringConfig);
-      activeIndex.value++;
-    }, [
-      index,
-      activeIndex,
-      maxCardTranslation,
-      onSwipeRight,
-      translateX,
-      swipeRightSpringConfig,
-    ]);
-
-    const swipeLeft = useCallback(() => {
-      onSwipeLeft?.(index);
-      translateX.value = withSpring(-maxCardTranslation, swipeLeftSpringConfig);
-      activeIndex.value++;
-    }, [
-      index,
-      activeIndex,
-      maxCardTranslation,
-      onSwipeLeft,
-      translateX,
-      swipeLeftSpringConfig,
-    ]);
-
-    const swipeTop = useCallback(() => {
-      onSwipeTop?.(index);
-      translateY.value = withSpring(-maxCardTranslationY, swipeTopSpringConfig);
-      activeIndex.value++;
-    }, [
-      index,
-      activeIndex,
-      maxCardTranslationY,
-      onSwipeTop,
-      translateY,
-      swipeTopSpringConfig,
-    ]);
-
-    const swipeBottom = useCallback(() => {
-      onSwipeBottom?.(index);
-      translateY.value = withSpring(
-        maxCardTranslationY,
-        swipeBottomSpringConfig
-      );
-      activeIndex.value++;
-    }, [
-      index,
-      activeIndex,
-      maxCardTranslationY,
-      onSwipeBottom,
-      translateY,
-      swipeBottomSpringConfig,
-    ]);
-
-    const swipeBack = useCallback(() => {
-      cancelAnimation(translateX);
-      cancelAnimation(translateY);
-      translateX.value = withSpring(0, swipeBackXSpringConfig);
-      translateY.value = withSpring(0, swipeBackYSpringConfig);
-    }, [
-      translateX,
-      translateY,
-      swipeBackXSpringConfig,
-      swipeBackYSpringConfig,
-    ]);
-
-    useImperativeHandle(
-      ref,
-      () => {
-        return {
-          swipeLeft,
-          swipeRight,
-          swipeBack,
-          swipeTop,
-          swipeBottom,
-        };
-      },
-      [swipeLeft, swipeRight, swipeBack, swipeTop, swipeBottom]
+  const inputRangeX = React.useMemo(() => {
+    return translateXRange ?? [];
+  }, [translateXRange]);
+  const inputRangeY = React.useMemo(() => {
+    return translateYRange ?? [];
+  }, [translateYRange]);
+  const rotateX = useDerivedValue(() => {
+    return interpolate(
+      translateX.value,
+      rotateInputRange ?? [],
+      rotateOutputRange ?? [],
+      'clamp'
     );
+  }, [inputRangeX]);
 
-    const inputRangeX = React.useMemo(() => {
-      return translateXRange ?? [];
-    }, [translateXRange]);
-    const inputRangeY = React.useMemo(() => {
-      return translateYRange ?? [];
-    }, [translateYRange]);
-    const rotateX = useDerivedValue(() => {
-      return interpolate(
+  const tap = Gesture.Tap().onEnd((_event, success) => {
+    if (success && onPress) {
+      runOnJS(onPress)();
+    }
+  });
+
+  const pan = Gesture.Pan()
+    .onBegin(() => {
+      nextActiveIndex.value = Math.floor(activeIndex.value);
+      if (onSwipeStart) runOnJS(onSwipeStart)();
+    })
+    .onUpdate((event) => {
+      // Use activeIndex.value directly in worklet context
+      const currentActive = Math.floor(activeIndex.value);
+      if (currentActive !== index) return;
+      if (onSwipeActive) runOnJS(onSwipeActive)();
+
+      translateX.value = event.translationX;
+      translateY.value = event.translationY;
+
+      if (height / 3 < Math.abs(event.translationY)) {
+        nextActiveIndex.value = interpolate(
+          translateY.value,
+          inputRangeY,
+          [currentActive + 1, currentActive, currentActive + 1],
+          'clamp'
+        );
+        return;
+      }
+
+      nextActiveIndex.value = interpolate(
         translateX.value,
-        rotateInputRange ?? [],
-        rotateOutputRange ?? [],
+        inputRangeX,
+        [currentActive + 1, currentActive, currentActive + 1],
         'clamp'
       );
-    }, [inputRangeX]);
-
-    const tap = Gesture.Tap().onEnd((_event, success) => {
-      if (success && onPress) {
-        runOnJS(onPress)();
-      }
-    });
-
-    const pan = Gesture.Pan()
-      .onBegin(() => {
-        nextActiveIndex.value = Math.floor(activeIndex.value);
-        if (onSwipeStart) runOnJS(onSwipeStart)();
-      })
-      .onUpdate((event) => {
-        // Use activeIndex.value directly in worklet context
-        const currentActive = Math.floor(activeIndex.value);
-        if (currentActive !== index) return;
-        if (onSwipeActive) runOnJS(onSwipeActive)();
-
-        translateX.value = event.translationX;
-        translateY.value = event.translationY;
-
-        if (height / 3 < Math.abs(event.translationY)) {
-          nextActiveIndex.value = interpolate(
+    })
+    .onFinalize((event) => {
+      const currentActive = Math.floor(activeIndex.value);
+      if (currentActive !== index) return;
+      if (onSwipeEnd) runOnJS(onSwipeEnd)();
+      if (nextActiveIndex.value === activeIndex.value + 1) {
+        const sign = Math.sign(event.translationX);
+        const signY = Math.sign(event.translationY);
+        const signPositionY = Number.isInteger(
+          interpolate(
             translateY.value,
             inputRangeY,
             [currentActive + 1, currentActive, currentActive + 1],
             'clamp'
-          );
-          return;
-        }
-
-        nextActiveIndex.value = interpolate(
-          translateX.value,
-          inputRangeX,
-          [currentActive + 1, currentActive, currentActive + 1],
-          'clamp'
+          )
         );
-      })
-      .onFinalize((event) => {
-        const currentActive = Math.floor(activeIndex.value);
-        if (currentActive !== index) return;
-        if (onSwipeEnd) runOnJS(onSwipeEnd)();
-
-        if (swipeVelocityThreshold !== undefined) {
-          if (Math.abs(event.velocityX) > swipeVelocityThreshold) {
-            const sign = Math.sign(event.velocityX);
-            if (sign === -1 && !disableLeftSwipe) {
-              runOnJS(swipeLeft)();
-              return;
-            }
-            if (sign === 1 && !disableRightSwipe) {
-              runOnJS(swipeRight)();
-              return;
-            }
-          }
-
-          if (Math.abs(event.velocityY) > swipeVelocityThreshold) {
-            const sign = Math.sign(event.velocityY);
-            if (sign === -1 && !disableTopSwipe) {
-              runOnJS(swipeTop)();
-              return;
-            }
-            if (sign === 1 && !disableBottomSwipe) {
-              runOnJS(swipeBottom)();
-              return;
-            }
-          }
-        }
-
-        if (nextActiveIndex.value === activeIndex.value + 1) {
-          const sign = Math.sign(event.translationX);
-          const signY = Math.sign(event.translationY);
-          const signPositionY = Number.isInteger(
-            interpolate(
-              translateY.value,
-              inputRangeY,
-              [currentActive + 1, currentActive, currentActive + 1],
-              'clamp'
-            )
-          );
-
-          if (signPositionY) {
-            if (signY === -1 && !disableTopSwipe) {
-              runOnJS(swipeTop)();
-              return;
-            }
-            if (signY === 1 && !disableBottomSwipe) {
-              runOnJS(swipeBottom)();
-              return;
-            }
-          }
-
-          if (!signPositionY) {
-            if (sign === 1 && !disableRightSwipe) {
-              runOnJS(swipeRight)();
-              return;
-            }
-            if (sign === -1 && !disableLeftSwipe) {
-              runOnJS(swipeLeft)();
-              return;
-            }
-          }
-        }
-        translateX.value = withSpring(0, swipeBackXSpringConfig);
-        translateY.value = withSpring(0, swipeBackYSpringConfig);
-      });
-
-    const rCardStyle = useAnimatedStyle(() => {
-      // Handle visibility and rendering based on prerenderItems using animated values
-      // Don't access activeIndex.value directly - use derived values instead
+      }
+    })
+    .onFinalize((event) => {
       const currentActive = Math.floor(activeIndex.value);
-      const shouldRender =
-        index < currentActive + prerenderItems && index >= currentActive - 1;
-      const indexDiff = index - currentActive;
+      if (currentActive !== index) return;
+      if (onSwipeEnd) runOnJS(onSwipeEnd)();
 
-      const opacity = withTiming(
-        shouldRender && indexDiff < prerenderItems ? 1 : 0
-      );
-      const scale = withTiming(1 - 0.07 * indexDiff);
+      if (swipeVelocityThreshold !== undefined) {
+        if (Math.abs(event.velocityX) > swipeVelocityThreshold) {
+          const sign = Math.sign(event.velocityX);
+          if (sign === -1 && !disableLeftSwipe) {
+            runOnJS(swipeLeft)();
+            return;
+          }
+          if (sign === 1 && !disableRightSwipe) {
+            runOnJS(swipeRight)();
+            return;
+          }
+        }
 
-      return {
-        opacity,
-        position: 'absolute',
-        zIndex: -index,
-        transform: [
-          { rotate: `${rotateX.value}rad` },
-          { scale: scale },
-          {
-            translateX: translateX.value,
-          },
-          {
-            translateY: translateY.value,
-          },
-        ],
-      };
+        if (Math.abs(event.velocityY) > swipeVelocityThreshold) {
+          const sign = Math.sign(event.velocityY);
+          if (sign === -1 && !disableTopSwipe) {
+            runOnJS(swipeTop)();
+            return;
+          }
+          if (sign === 1 && !disableBottomSwipe) {
+            runOnJS(swipeBottom)();
+            return;
+          }
+        }
+      }
+
+      if (nextActiveIndex.value === activeIndex.value + 1) {
+        const sign = Math.sign(event.translationX);
+        const signY = Math.sign(event.translationY);
+        const signPositionY = Number.isInteger(
+          interpolate(
+            translateY.value,
+            inputRangeY,
+            [currentActive + 1, currentActive, currentActive + 1],
+            'clamp'
+          )
+        );
+
+        if (signPositionY) {
+          if (signY === -1 && !disableTopSwipe) {
+            runOnJS(swipeTop)();
+            return;
+          }
+          if (signY === 1 && !disableBottomSwipe) {
+            runOnJS(swipeBottom)();
+            return;
+          }
+        }
+
+        if (!signPositionY) {
+          if (sign === 1 && !disableRightSwipe) {
+            runOnJS(swipeRight)();
+            return;
+          }
+          if (sign === -1 && !disableLeftSwipe) {
+            runOnJS(swipeLeft)();
+            return;
+          }
+        }
+      }
+      translateX.value = withSpring(0, swipeBackXSpringConfig);
+      translateY.value = withSpring(0, swipeBackYSpringConfig);
     });
 
-    const composed = Gesture.Race(tap, pan);
+  const rCardStyle = useAnimatedStyle(() => {
+    // Handle visibility and rendering based on prerenderItems using animated values
+    // Don't access activeIndex.value directly - use derived values instead
+    const currentActive = Math.floor(activeIndex.value);
+    const shouldRender =
+      index < currentActive + prerenderItems && index >= currentActive - 1;
+    const indexDiff = index - currentActive;
 
-    return (
-      <GestureDetector gesture={composed}>
-        <Animated.View style={[cardStyle, rCardStyle]}>
-          {OverlayLabelLeft && (
-            <OverlayLabel
-              inputRange={inputOverlayLabelLeftOpacityRange}
-              outputRange={outputOverlayLabelLeftOpacityRange}
-              Component={OverlayLabelLeft}
-              opacityValue={translateX}
-            />
-          )}
-          {OverlayLabelRight && (
-            <OverlayLabel
-              inputRange={inputOverlayLabelRightOpacityRange}
-              outputRange={outputOverlayLabelRightOpacityRange}
-              Component={OverlayLabelRight}
-              opacityValue={translateX}
-            />
-          )}
-          {OverlayLabelTop && (
-            <OverlayLabel
-              inputRange={inputOverlayLabelTopOpacityRange}
-              outputRange={outputOverlayLabelTopOpacityRange}
-              Component={OverlayLabelTop}
-              opacityValue={translateY}
-            />
-          )}
-          {OverlayLabelBottom && (
-            <OverlayLabel
-              inputRange={inputOverlayLabelBottomOpacityRange}
-              outputRange={outputOverlayLabelBottomOpacityRange}
-              Component={OverlayLabelBottom}
-              opacityValue={translateY}
-            />
-          )}
+    const opacity = withTiming(
+      shouldRender && indexDiff < prerenderItems ? 1 : 0
+    );
+    const scale = withTiming(1 - 0.07 * indexDiff);
 
+    return {
+      opacity,
+      position: 'absolute',
+      zIndex: -index,
+      transform: [
+        { rotate: `${rotateX.value}rad` },
+        { scale: scale },
+        {
+          translateX: translateX.value,
+        },
+        {
+          translateY: translateY.value,
+        },
+      ],
+    };
+  });
+
+  const isDirectionX = direction === 'x';
+  const regularCardAnimatedStyle = useAnimatedStyle(() => {
+    const spinValue = interpolate(Number(isFlipped.value), [0, 1], [0, 180]);
+    const rotateValue = withTiming(`${spinValue}deg`, {
+      duration: flipDuration,
+    });
+
+    return {
+      transform: [
+        isDirectionX ? { rotateX: rotateValue } : { rotateY: rotateValue },
+      ],
+      position: 'absolute',
+      backfaceVisibility: 'hidden',
+      zIndex: isFlipped.value ? 1 : 2,
+    };
+  });
+
+  const flippedCardAnimatedStyle = useAnimatedStyle(() => {
+    const spinValue = interpolate(Number(isFlipped.value), [0, 1], [180, 360]);
+    const rotateValue = withTiming(`${spinValue}deg`, {
+      duration: flipDuration,
+    });
+
+    return {
+      transform: [
+        isDirectionX ? { rotateX: rotateValue } : { rotateY: rotateValue },
+      ],
+      backfaceVisibility: 'hidden',
+      zIndex: isFlipped.value ? 2 : 1,
+    };
+  });
+
+  const composed = Gesture.Race(tap, pan);
+
+  return (
+    <GestureDetector gesture={composed}>
+      <Animated.View style={[rCardStyle, cardStyle]}>
+        {OverlayLabelLeft && (
+          <OverlayLabel
+            overlayLabelContainerStyle={overlayLabelContainerStyle}
+            inputRange={inputOverlayLabelLeftOpacityRange}
+            outputRange={outputOverlayLabelLeftOpacityRange}
+            Component={OverlayLabelLeft}
+            opacityValue={translateX}
+          />
+        )}
+        {OverlayLabelRight && (
+          <OverlayLabel
+            overlayLabelContainerStyle={overlayLabelContainerStyle}
+            inputRange={inputOverlayLabelRightOpacityRange}
+            outputRange={outputOverlayLabelRightOpacityRange}
+            Component={OverlayLabelRight}
+            opacityValue={translateX}
+          />
+        )}
+        {OverlayLabelTop && (
+          <OverlayLabel
+            overlayLabelContainerStyle={overlayLabelContainerStyle}
+            inputRange={inputOverlayLabelTopOpacityRange}
+            outputRange={outputOverlayLabelTopOpacityRange}
+            Component={OverlayLabelTop}
+            opacityValue={translateY}
+          />
+        )}
+        {OverlayLabelBottom && (
+          <OverlayLabel
+            overlayLabelContainerStyle={overlayLabelContainerStyle}
+            inputRange={inputOverlayLabelBottomOpacityRange}
+            outputRange={outputOverlayLabelBottomOpacityRange}
+            Component={OverlayLabelBottom}
+            opacityValue={translateY}
+          />
+        )}
+        <Animated.View
+          style={[
+            StyleSheet.flatten([regularCardStyle, cardStyle]),
+            regularCardAnimatedStyle,
+          ]}
+        >
           {children}
         </Animated.View>
-      </GestureDetector>
-    );
-  }
-);
+        {hasFlippedContent && (
+          <Animated.View
+            style={[
+              StyleSheet.flatten([flippedCardStyle, cardStyle]),
+              flippedCardAnimatedStyle,
+            ]}
+          >
+            {FlippedContent(item, index)}
+          </Animated.View>
+        )}
+      </Animated.View>
+    </GestureDetector>
+  );
+});
 
-export default memo(SwipeableCard);
+export default memo(SwipeableCard) as typeof SwipeableCard;

--- a/src/hooks/useSwipeControls.ts
+++ b/src/hooks/useSwipeControls.ts
@@ -77,6 +77,14 @@ const useSwipeControls = <T>(data: T[], loop: boolean = false) => {
     updateActiveIndex();
   }, [refs, updateActiveIndex, activeIndex]);
 
+  const flipCard = useCallback(() => {
+    const currentIndex = Math.floor(activeIndex.value);
+    if (!refs[currentIndex]) {
+      return;
+    }
+    refs[currentIndex]?.current?.flipCard();
+  }, [activeIndex, refs]);
+
   const swipeBack = useCallback(() => {
     const previousIndex = activeIndex.value - 1;
 
@@ -102,6 +110,7 @@ const useSwipeControls = <T>(data: T[], loop: boolean = false) => {
     swipeBack,
     swipeTop,
     swipeBottom,
+    flipCard,
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type SwiperCardRefType =
       swipeBack: () => void;
       swipeTop: () => void;
       swipeBottom: () => void;
+      flipCard: () => void;
     }
   | undefined;
 
@@ -18,9 +19,13 @@ export type SwiperOptions<T> = {
   //* Card Props
   data: T[];
   renderCard: (item: T, index: number) => JSX.Element;
+  FlippedContent?: (item: T, index: number) => JSX.Element;
   prerenderItems?: number;
   cardStyle?: StyleProp<ViewStyle>;
+  flippedCardStyle?: StyleProp<ViewStyle>;
+  regularCardStyle?: StyleProp<ViewStyle>;
   loop?: boolean;
+  keyExtractor?: (item: T, index: number) => string | number;
   //* Event callbacks
   onSwipeLeft?: (cardIndex: number) => void;
   onSwipeRight?: (cardIndex: number) => void;
@@ -63,10 +68,13 @@ export type SwiperOptions<T> = {
   swipeLeftSpringConfig?: SpringConfig;
   swipeTopSpringConfig?: SpringConfig;
   swipeBottomSpringConfig?: SpringConfig;
-  keyExtractor?: (item: T, index: number) => string;
   swipeVelocityThreshold?: number;
+  direction?: 'x' | 'y';
+  flipDuration?: number;
+  overlayLabelContainerStyle?: StyleProp<ViewStyle>;
 };
-export type SwiperCardOptions = {
+export type SwiperCardOptions<T> = {
+  item: T;
   index: number;
   activeIndex: SharedValue<number>;
   prerenderItems?: number;
@@ -79,6 +87,8 @@ export type SwiperCardOptions = {
   onSwipeEnd?: () => void;
   onPress?: () => void;
   cardStyle?: StyleProp<ViewStyle>;
+  flippedCardStyle?: StyleProp<ViewStyle>;
+  regularCardStyle?: StyleProp<ViewStyle>;
   loop?: boolean;
   disableRightSwipe?: boolean;
   disableLeftSwipe?: boolean;
@@ -100,6 +110,7 @@ export type SwiperCardOptions = {
   OverlayLabelLeft?: () => JSX.Element;
   OverlayLabelTop?: () => JSX.Element;
   OverlayLabelBottom?: () => JSX.Element;
+  FlippedContent?: (item: T, index: number) => JSX.Element;
   swipeBackXSpringConfig?: SpringConfig;
   swipeBackYSpringConfig?: SpringConfig;
   swipeRightSpringConfig?: SpringConfig;
@@ -107,4 +118,7 @@ export type SwiperCardOptions = {
   swipeTopSpringConfig?: SpringConfig;
   swipeBottomSpringConfig?: SpringConfig;
   swipeVelocityThreshold?: number;
+  direction?: 'x' | 'y';
+  flipDuration?: number;
+  overlayLabelContainerStyle?: StyleProp<ViewStyle>;
 };


### PR DESCRIPTION
This PR introduces a new feature that allows cards to be flipped via a tap gesture or programmatically. This enhancement enables developers to display additional content or details on the back of the card, creating a more interactive user experience.

#### Key Changes:

*   **`FlippedContent` Prop:** A new prop to render the component for the backface of the card.
*   **`flipCard()` Method:** A new method exposed via `ref` to programmatically trigger the flip animation.
*   **Customizable Animation:**
    *   `direction` ('x' or 'y'): Controls the axis of the flip animation.
    *   `flipDuration`: Sets the duration of the animation in milliseconds.
*   **Separate Styling:** Added `regularCardStyle` and `flippedCardStyle` props to allow distinct styling for the front and back of the card.

#### How to Use:

```jsx
import { Swiper, type SwiperCardRefType } from 'rn-swiper-list';
import { useRef } from 'react';

const swiperRef = useRef<SwiperCardRefType>(null);

const FlippedComponent = ({ item }) => (
  <View style={styles.flippedView}>
    <Text>Details: {item.details}</Text>
  </View>
);

<Swiper
  ref={swiperRef}
  data={myData}
  renderCard={(item) => <CardComponent data={item} />}
  FlippedContent={(item) => <FlippedComponent item={item} />}
  direction="y"
  flipDuration={500}
/>

<Button
  title="Flip Card"
  onPress={() => swiperRef.current?.flipCard()}
/>
```

#### Visual Proof:

https://github.com/user-attachments/assets/71e90187-849c-4bce-b338-b5138a8e15e4

